### PR TITLE
Fix vcf_filter rules ignoring config.yaml parameters

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Usage
 
 ::
 
-    sequana_variant_calling --input-directory DATAPATH --reference-file measles.fa 
+    sequana_variant_calling --input-directory DATAPATH --reference-file measles.fa
 
 This creates a directory **variant_calling**. You just need to move into the directory and execute the script::
 
@@ -85,7 +85,7 @@ Requirements
 ~~~~~~~~~~~~
 
 If you rely on singularity/apptainer, no extra dependencies are required (expect python and
-https://damona.readthedocs.io). If you cannot use apptainer, you will need to install some software: 
+https://damona.readthedocs.io). If you cannot use apptainer, you will need to install some software:
 
 - bwa
 - freebayes
@@ -155,8 +155,8 @@ Initiate the pipeline::
 
     sequana_variant_calling --input-directory . --reference-file ecoli.fa --aligner-choice bwa_split \
         --do-coverage --annotation-file ecoli.gff  \
-        --use-apptainer --apptainer-prefix ~/.sequana/apptainers \ 
-        --input-readtag "_[12]." 
+        --use-apptainer --apptainer-prefix ~/.sequana/apptainers \
+        --input-readtag "_[12]."
 
 Explication:
 
@@ -189,17 +189,22 @@ Changelog
 ========= ======================================================================
 Version   Description
 ========= ======================================================================
+1.6.0     * Fix freebayes_vcf_filter and joint_freebayes_vcf_filter rules that
+            ignored their config.yaml settings: the filter parameters
+            (frequency, freebayes_score, min_depth, etc.) were never passed to
+            the sequana html-report command, so CLI defaults were always used.
+            joint_freebayes_vcf_filter also read the wrong config section.
 1.5.0     * use new sequana-wrappers shells
 1.4.0     * handles long reads data. Use sequana html_report to create the VCF
-            html reports instead of wrapper. More dynamic. Updated some 
+            html reports instead of wrapper. More dynamic. Updated some
             containers, in particular for sequana_coverage.
           * Fixed regression in bwa mapping
-          * Fixed ordering of contigs on genomecov that was not sorted in the 
+          * Fixed ordering of contigs on genomecov that was not sorted in the
             same way as samtools in some cases.
-          * use new sequana-wrappers.shells (instead of wrappers) 
-1.3.0     * Updated version to use latest damona containers and latest 
+          * use new sequana-wrappers.shells (instead of wrappers)
+1.3.0     * Updated version to use latest damona containers and latest
             sequana version 0.19.1. added plot in HTML report with distribution
-            of variants. added tutorial. added bwa_split and freebaye split to 
+            of variants. added tutorial. added bwa_split and freebaye split to
             process ultra deep sequencing.
 1.2.0     * -Xmx8g option previously added is not robust. Does not work with
             snpEff 5.1 for instance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "sequana-variant-calling"
-version = "1.5.0"
+version = "1.6.0"
 description = "A multi-sample variant calling pipeline"
 authors = [{name="Sequana Team"}]
 license = "BSD-3"

--- a/sequana_pipelines/variant_calling/variant_calling.rules
+++ b/sequana_pipelines/variant_calling/variant_calling.rules
@@ -711,6 +711,13 @@ rule freebayes_vcf_filter:
         """
         # requires sequana 0.19.4
         sequana html-report {input} \
+            --freebayes-score {params.filter_dict[freebayes_score]} \
+            --frequency {params.filter_dict[frequency]} \
+            --min-depth {params.filter_dict[min_depth]} \
+            --forward-depth {params.filter_dict[forward_depth]} \
+            --reverse-depth {params.filter_dict[reverse_depth]} \
+            --strand-ratio {params.filter_dict[strand_ratio]} \
+            --keep-polymorphic {params.filter_dict[keep_polymorphic]} \
             --output-vcf-file {output.vcf} \
             --output-csv-file {output.csv} \
             --output-directory {wildcards.sample}
@@ -801,7 +808,7 @@ if config["joint_freebayes"]["do"]:
             csv="joint_calling/joint_calling.filter.csv",
             html="joint_calling/variant_calling.html"
         params:
-            filter_dict=config["freebayes_vcf_filter"],
+            filter_dict=config["joint_freebayes_vcf_filter"],
             report_dir="joint_calling"
         container:
             config['apptainers']['sequana_tools']
@@ -810,6 +817,9 @@ if config["joint_freebayes"]["do"]:
         shell:
             """
             sequana html-report {input} \
+                --freebayes-score {params.filter_dict[freebayes_score]} \
+                --frequency {params.filter_dict[frequency]} \
+                --min-depth {params.filter_dict[min_depth]} \
                 --output-vcf-file {output.vcf} \
                 --output-csv-file {output.csv} \
                 --output-directory {params.report_dir}


### PR DESCRIPTION
The freebayes_vcf_filter and joint_freebayes_vcf_filter rules defined params.filter_dict but never passed it to the sequana html-report command, so the CLI defaults (frequency 0.1, freebayes_score 20, etc.) were always used and config.yaml settings had no effect. joint_freebayes_vcf_filter also read the wrong config section (freebayes_vcf_filter instead of joint_freebayes_vcf_filter).

Bump version to 1.6.0 and update changelog.