### PR TITLE
ci: install bcftools explicitly in test workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,11 @@ jobs:
           cache-environment: true
           cache-downloads: true
 
+    - name: install bcftools
+      run: |
+        micromamba install -y -n sequana_variant_calling -c conda-forge -c bioconda bcftools
+        micromamba run -n sequana_variant_calling bcftools --version
+
     - name: install package itself
       shell: bash -l {0}
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,13 +36,16 @@ jobs:
           environment-file: environment.yml
           create-args: >-
             python=${{ matrix.python }}
-          cache-environment: true
+          # environment caching is disabled on purpose: restored envs kept the
+          # package metadata but lost files on disk, so bcftools was reported as
+          # installed while libgsl.so.25 was missing at runtime
+          cache-environment: false
           cache-downloads: true
 
-    - name: install bcftools
+    - name: check bcftools
+      shell: bash -l {0}
       run: |
-        micromamba install -y -n sequana_variant_calling -c conda-forge -c bioconda bcftools
-        micromamba run -n sequana_variant_calling bcftools --version
+        bcftools --version
 
     - name: install package itself
       shell: bash -l {0}

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -3,10 +3,10 @@ Sequana variant calling pipeline documentation
 
 |version|, |today|, status:production
 
-The **variant_calling** pipeline is a `Sequana <https://github.com/sequana/sequana>`_ pipeline. You can find the source code 
+The **variant_calling** pipeline is a `Sequana <https://github.com/sequana/sequana>`_ pipeline. You can find the source code
 on  `https://github.com/sequana/sequana_variant_calling <https://github.com/sequana/sequana_variant_calling/>`_. Would you have issues
-about the code, usage or lack of information, please fill a report 
-on `Sequana  itself <https://github.com/sequana/sequana/issues>`_ indicating the pipeline name (We centralized all 
+about the code, usage or lack of information, please fill a report
+on `Sequana  itself <https://github.com/sequana/sequana/issues>`_ indicating the pipeline name (We centralized all
 pipelines issues on **Sequana** repository only so as to be more responsive).
 
 If you use **Sequana**, please do not forget to cite us:
@@ -38,4 +38,3 @@ What is Sequana ?
 To join the project, please let us know on `github <https://github.com/sequana/sequana/issues/306>`_.
 
 For more information, please see `github <https://sequana.readthedocs.io>`_.
-

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
 - freebayes>1.3
 - bwa
 - bcftools
+- gsl
 - snpeff==5.1d
 - sambamba
 - fastp


### PR DESCRIPTION
bcftools is listed in environment.yml but was missing at test time, likely due to a stale cached environment. Install it explicitly after micromamba setup and verify the binary resolves.